### PR TITLE
feat: adding sync monitor tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,19 +352,27 @@
             }
 
             renderProductiveServers() {
+                const shouldCompareSnapshots = window.location.href.toString().indexOf("includeDevServers") >= 0
+                let compareSnapshots = ""
+                if (shouldCompareSnapshots) {
+                    let result = ""
+                    if (this.state.syncCheck) {
+                        result = this.state.syncCheck.size === 0 ?
+                            "  Calculating..." :
+                            (<ul>{ Array.from(this.state.syncCheck.entries()).map(([server, value]) => <li>{server}: {value}</li>) }</ul>)
+                    }
+                    compareSnapshots = (
+                        <div>
+                            <input type="button" value="Compare Snapshots" onClick={() => this.verifySync(productiveServers)}/>
+                            { result }
+                        </div>
+                    )
+                }
                 return (
                     <div>
                         <div className="node-set">{productiveServers.map(server => {return (<ServerMonitor address={server} expectedEthNetwork="mainnet" contributeUsers={(usersCount) => this.sumProductiveUsers(usersCount)} contributeCommitHash={(commitHash => this.addCommitHash(commitHash))} />)})}</div>
                         <div className="total-productive-users">Total Users: {this.state.totalProductiveUsers}</div>
-                        <input type="button" value="Compare Snapshots" onClick={() => this.verifySync(productiveServers)}/>
-                        {
-                            this.state.syncCheck ? (
-                                this.state.syncCheck.size === 0 ?
-                                    "  Calculating..." :
-                                    (<ul>{ Array.from(this.state.syncCheck.entries()).map(([server, value]) => <li>{server}: {value}</li>) }</ul>)
-                            )
-                            : ""
-                        }
+                        { compareSnapshots }
                     </div>
                 );
             }

--- a/index.html
+++ b/index.html
@@ -173,15 +173,21 @@
         }
 
         function ContentServer(props) {
-            const clusterInfo = props.status.synchronizationStatus ? props.status.synchronizationStatus : (props.status.clusterStatus ? props.status.clusterStatus : undefined)
+            const clusterInfo = props.status.synchronizationStatus
             const expectedEthNetworkOk = props.status.ethNetwork === props.expectedEthNetwork
+            let otherServers = 0
+            let connectedOtherServers = 0
+            if (clusterInfo) {
+                otherServers = clusterInfo.otherServers.length
+                connectedOtherServers = clusterInfo.otherServers.filter(({ connectionState }) => connectionState === 'Connected').length
+            }
             return (
                 <div className="content" onClick={() => showFullStatus(props, "content", [{name: "Failed Deployments", data: props.failedDeployments}])}>
                     <b>Content - {shortHash(props.status.commitHash)}</b>
-                    <div>CTD: {deltaTime(props.status.currentTime)}</div>
-                    <div>ITD: {deltaTime(props.status.lastImmutableTime)}</div>
                     <div>History #: {props.status.historySize}</div>
-                    <div>DAO #: {clusterInfo ? clusterInfo.otherServers.length : 0}</div>
+                    <div>State: {clusterInfo ? clusterInfo.synchronizationState : "Unknown"}</div>
+                    <div>LastSync: {clusterInfo ? deltaTime(clusterInfo.lastSyncWithOtherServers) : "Unknown"}</div>
+                    <div>DAO #: {`${connectedOtherServers}/${otherServers}`}</div>
                     <div>Failed: {Array.isArray(props.failedDeployments) ? props.failedDeployments.length : props.failedDeployments}</div>
                     <div>{!expectedEthNetworkOk ? "Eth: " + props.status.ethNetwork : ""}</div>
                 </div>
@@ -235,25 +241,29 @@
         function deltaTime(externalTime) {
             if (externalTime) {
                 const deltaMillis = new Date() - externalTime
-                if (deltaMillis < 1000) {
-                    return `${deltaMillis} millis`
-                }
-                const deltaSeconds = deltaMillis / 1000
-                if (deltaSeconds < 60) {
-                    return `${deltaSeconds.toFixed(2)} secs`
-                }
-                const deltaMinutes = deltaSeconds / 60
-                if (deltaMinutes < 60) {
-                    return `${deltaMinutes.toFixed(2)} mins`
-                }
-                const deltaHours = deltaMinutes / 60
-                if (deltaHours < 24) {
-                    return `${deltaHours.toFixed(2)} hours`
-                }
-                const deltaDays = deltaHours / 24
-                return `${deltaDays.toFixed(2)} days`
+                return millisToHumanTime(deltaMillis)
             }
             return "Unknown time"
+        }
+
+        function millisToHumanTime(millis) {
+            if (millis < 1000) {
+                return `${millis} millis`
+            }
+            const seconds = millis / 1000
+            if (seconds < 60) {
+                return `${seconds.toFixed(2)} secs`
+            }
+            const minutes = seconds / 60
+            if (minutes < 60) {
+                return `${minutes.toFixed(2)} mins`
+            }
+            const hours = minutes / 60
+            if (hours < 24) {
+                return `${hours.toFixed(2)} hours`
+            }
+            const days = hours / 24
+            return `${days.toFixed(2)} days`
         }
 
         function toISOString(externalTime) {
@@ -269,7 +279,7 @@
             'https://peer-ec1.decentraland.org',       // DCL - US East
             'https://peer-wc1.decentraland.org',       // DCL - US West
             'https://peer-eu1.decentraland.org',       // DCL - EU
-            'https://peer.manaland.cn',                // DCL - China
+            'https://peer-ap1.decentraland.org',
             'https://interconnected.online',           // Esteban
             'https://peer.decentral.games',            // Baus
             'https://peer.melonwave.com',              // Ari
@@ -278,11 +288,21 @@
             'https://peer.uadevops.com',               // SFox
             'https://peer.dclnodes.io',                // DSM
         ]
+
+        const nonDAOMainnetServers = [
+            'https://peer.manaland.cn',                // DCL - China
+            'https://bot1-catalyst.decentraland.org',
+        ]
+
         const zoneServers = [
             'https://peer.decentraland.zone',
             'https://bot1-catalyst.decentraland.zone',
             'https://bot2-katalyst.decentraland.zone',
         ]
+
+        const DEFAULT_SYNC_INTERVAL = 2 * 60 * 1000 // 2 minutes
+        const MAX_URL_LENGTH = 2048
+        const ENTITY_TYPES = ['scene', 'profile']
 
         class Servers extends React.Component {
             constructor(props) {
@@ -290,12 +310,18 @@
                 this.state = {
                     totalProductiveUsers: 0,
                     totalDevUsers: 0,
-                    commitsHashesInfo: {}
+                    totalNonDAOMainnetUsers: 0,
+                    commitsHashesInfo: {},
+                    syncCheck: undefined,
                 };
             }
 
             sumProductiveUsers(usersCount) {
                 this.setState({ totalProductiveUsers: this.state.totalProductiveUsers + usersCount })
+            }
+
+            sumNonDAOMainnetUsers(usersCount) {
+                this.setState({ totalNonDAOMainnetUsers: this.state.totalNonDAOMainnetUsers + usersCount })
             }
 
             sumDevUsers(usersCount) {
@@ -330,6 +356,15 @@
                     <div>
                         <div className="node-set">{productiveServers.map(server => {return (<ServerMonitor address={server} expectedEthNetwork="mainnet" contributeUsers={(usersCount) => this.sumProductiveUsers(usersCount)} contributeCommitHash={(commitHash => this.addCommitHash(commitHash))} />)})}</div>
                         <div className="total-productive-users">Total Users: {this.state.totalProductiveUsers}</div>
+                        <input type="button" value="Compare Snapshots" onClick={() => this.verifySync(productiveServers)}/>
+                        {
+                            this.state.syncCheck ? (
+                                this.state.syncCheck.size === 0 ?
+                                    "  Calculating..." :
+                                    (<ul>{ Array.from(this.state.syncCheck.entries()).map(([server, value]) => <li>{server}: {value}</li>) }</ul>)
+                            )
+                            : ""
+                        }
                     </div>
                 );
             }
@@ -339,6 +374,8 @@
                 if ( currentUrl.indexOf("includeDevServers")>=0 ) {
                     return (
                         <div>
+                            <div className="node-set">{nonDAOMainnetServers.map(server => {return (<ServerMonitor address={server} expectedEthNetwork="mainnet" contributeUsers={(usersCount) => this.sumNonDAOMainnetUsers(usersCount)} contributeCommitHash={(commitHash => this.addCommitHash(commitHash))} />)})}</div>
+                            <div className="total-productive-users">Total Users: {this.state.totalNonDAOMainnetUsers}</div>
                             <div className="node-set">{zoneServers.map(server => {return (<ServerMonitor address={server} expectedEthNetwork="ropsten" contributeUsers={(usersCount) => this.sumDevUsers(usersCount)} contributeCommitHash={(commitHash => this.addCommitHash(commitHash))} />)})}</div>
                             <div className="total-dev-users">Total Users: {this.state.totalDevUsers}</div>
                         </div>
@@ -358,6 +395,175 @@
                         )})}
                     </div>
                 );
+            }
+
+            async verifySync(servers) {
+                const referenceServer = servers[0]
+                this.setState({ syncCheck: new Map() })
+                const referenceSnapshotsEntries = await Promise.all(ENTITY_TYPES.map((entityType) => this.fetchSnapshot(referenceServer, entityType).then(snapshot => [entityType, snapshot])))
+                const referenceSnapshots = new Map(referenceSnapshotsEntries)
+
+                const compares = await Promise.all(servers.slice(1).map(server => this.compareAgainstReference(referenceServer, referenceSnapshots, server)))
+
+                const syncResult = new Map()
+                for (const { worstEntityId, worstTimeDiff, error, server } of compares) {
+                    if (error) {
+                        syncResult.set(server, `An error happened: ${error}`)
+                    } else if (worstEntityId) {
+                        syncResult.set(server, `A difference of ${millisToHumanTime(worstTimeDiff)} was found. Check entity ${worstEntityId}`)
+                    } else {
+                        syncResult.set(server, 'No differences found')
+                    }
+                }
+
+                this.setState({ syncCheck: syncResult })
+            }
+
+            async compareAgainstReference(referenceServer, referenceSnapshots, server) {
+                let worstEntityId = undefined
+                let worstTimeDiff = 0
+                let errorMessage = undefined
+
+                try {
+                    for (const entityType of ENTITY_TYPES) {
+                        const [referenceSnapshotTime, referenceSnapshot] = referenceSnapshots.get(entityType)
+                        const [serverSnapshotTime, serverSnapshot] = await this.fetchSnapshot(server, entityType)
+                        const { maxDiff, maxDiffEntity } = await this.diff(referenceServer, referenceSnapshotTime, referenceSnapshot, server, serverSnapshotTime, serverSnapshot)
+                        if (maxDiff > worstTimeDiff) {
+                            worstTimeDiff = maxDiff
+                            worstEntityId = maxDiffEntity
+                        }
+                    }
+                } catch (error) {
+                    errorMessage = `${error}`
+                }
+
+                return { worstEntityId, worstTimeDiff, server, error: errorMessage }
+            }
+
+            /** Fetch the snapshot's content and timestamp */
+            async fetchSnapshot(server, type) {
+                const response = await fetch(`${server}/content/snapshot/${type}`)
+                if (!response.ok) {
+                    throw new Error(`Failed to download snapshot. Status was: ${response.status}`)
+                }
+                const { hash, lastIncludedDeploymentTimestamp } = await response.json()
+                const snapshotContentResponse = await fetch(`${server}/content/contents/${hash}`)
+                if (!snapshotContentResponse.ok) {
+                    throw new Error(`Failed to download snapshot. Status was: ${snapshotContentResponse.status}`)
+                }
+                const snapshotContent = await snapshotContentResponse.json()
+                return [lastIncludedDeploymentTimestamp, this.reverse(new Map(snapshotContent))]
+            }
+
+            /** Given a reference and compare snapshot, calculate the max differente */
+            async diff(referenceServer, referenceSnapshotTime, referenceSnapshot, compareServer, compareSnapshotTime, compareSnapshot) {
+                // Combine all pointers
+                const pointers = new Set([...referenceSnapshot.keys(), ...compareSnapshot.keys()])
+                const conflicts = []
+                const conflictedEntitiesReference = new Set()
+                const conflictedEntitiesCompare = new Set()
+
+                // Find differences/conflicts on the pointers
+                for (const pointer of pointers) {
+                    const referenceEntity = referenceSnapshot.get(pointer)
+                    const compareEntity = compareSnapshot.get(pointer)
+
+                    if (referenceEntity !== compareEntity) {
+                        if (referenceEntity) {
+                            conflictedEntitiesReference.add(referenceEntity)
+                        }
+                        if (compareEntity) {
+                            conflictedEntitiesCompare.add(compareEntity)
+                        }
+                        conflicts.push([referenceEntity, compareEntity])
+                    }
+                }
+
+                if (conflicts.length > 10000) {
+                    throw new Error(`Too many differences found. Found ${conflicts.length} differences`)
+                }
+
+                // For each conflicted entity, find their timestamps. This will be needed to calculate the difference
+                const referenceEntityTimestamps = await this.checkEntityTimes(referenceServer, conflictedEntitiesReference)
+                const compareEntityTimestamps = await this.checkEntityTimes(compareServer, conflictedEntitiesCompare)
+
+                let maxDiffEntity = undefined
+                let maxDiff = 0
+
+                for (const [referenceEntity, compareEntity] of conflicts) {
+                    const { entityTimestamp: referenceEntityTimestamp, localTimestamp: referenceLocalTimestamp } = referenceEntityTimestamps.has(referenceEntity) ? referenceEntityTimestamps.get(referenceEntity) : ({ entityTimestamp: 0, localTimestamp: 0 })
+                    const { entityTimestamp: compareEntityTimestamp, localTimestamp: compareLocalTimestamp } = compareEntityTimestamps.has(compareEntity) ? compareEntityTimestamps.get(compareEntity) : ({ entityTimestamp: 0, localTimestamp: 0 })
+
+                    // Check if differences are actually valid. They might be, since consistency is only eventual
+                    if (referenceEntityTimestamp > compareEntityTimestamp && compareSnapshotTime < referenceLocalTimestamp + DEFAULT_SYNC_INTERVAL * 2) {
+                        // Valid difference
+                        continue
+                    } else if (referenceEntityTimestamp < compareEntityTimestamp && referenceSnapshotTime < compareLocalTimestamp + DEFAULT_SYNC_INTERVAL * 2) {
+                        // Valid difference
+                        continue
+                    }
+
+                    // Calculate how "old" the error is. The idea is that the longest the error goes unresolved, the bigger this value will be
+                    const errorAge = Date.now() - Math.max(referenceLocalTimestamp, compareLocalTimestamp)
+
+                    // Calculate the difference between the entities' timestamps. As long as the conflicted entities are the same, this value won't change
+                    const entityDiff = Math.abs(referenceEntityTimestamp - compareEntityTimestamp)
+
+                    // Update with the biggest diff
+                    const diff = entityDiff + errorAge
+                    if (diff > maxDiff) {
+                        maxDiff = diff
+                        maxDiffEntity = compareEntity
+                    }
+                }
+
+                return { maxDiffEntity, maxDiff }
+            }
+
+            /** Fetch all relevant timestamps for the given entities. We might need to make more than one request. */
+            async checkEntityTimes(server, entities) {
+                if (entities.size == 0) {
+                    return new Map()
+                }
+
+                const result = []
+                const entitiesToFetch = [...entities]
+                let url = `${server}/content/deployments?fields=auditInfo`
+                for (let i = 0; i < entitiesToFetch.length; i++) {
+                    const newQueryParam = `&entityId=${entitiesToFetch[i]}`
+                    if (url.length + newQueryParam.length > MAX_URL_LENGTH) {
+                        const response = await fetch(url)
+                        const { deployments } = await response.json()
+                        deployments
+                            .map(({ entityId, entityTimestamp, auditInfo }) => [entityId, { entityTimestamp, localTimestamp: auditInfo.localTimestamp }])
+                            .forEach(entry => result.push(entry))
+                        url = `${server}/content/deployments?fields=auditInfo`
+                    }
+                    url = url + newQueryParam
+                }
+
+                const response = await fetch(url)
+                const { deployments } = await response.json()
+                deployments
+                    .map(({ entityId, entityTimestamp, auditInfo }) => [entityId, { entityTimestamp, localTimestamp: auditInfo.localTimestamp }])
+                    .forEach(entry => result.push(entry))
+
+                return new Map(result)
+            }
+
+            // Takes a Map<EntityId, Pointer[]> and returns a Map<Pointer, EntityId>
+            reverse(snapshot) {
+                const result = new Map()
+                for (const [ entityId, pointers ] of snapshot) {
+                    for (const pointer of pointers) {
+                        if (result.has(pointer)) {
+                            throw new Error(`Snapshot has pointer in more than one entity. First was '${result.get(pointer)}' and the second one is ${entityId}`)
+                        }
+                        result.set(pointer, entityId)
+                    }
+                }
+                return result
             }
 
             render() {

--- a/index.html
+++ b/index.html
@@ -359,11 +359,11 @@
                     if (this.state.syncCheck) {
                         result = this.state.syncCheck.size === 0 ?
                             "  Calculating..." :
-                            (<ul>{ Array.from(this.state.syncCheck.entries()).map(([server, value]) => <li>{server}: {value}</li>) }</ul>)
+                            (<ul>{ Array.from(this.state.syncCheck.entries()).map(([server, value]) => <li><b>{server}</b>: {value}</li>) }</ul>)
                     }
                     compareSnapshots = (
                         <div>
-                            <input type="button" value="Compare Snapshots" onClick={() => this.verifySync(productiveServers)}/>
+                            <input type="button" title="Compare against peer.decentraland.org" value="Compare Snapshots" onClick={() => this.verifySync(productiveServers )}/>
                             { result }
                         </div>
                     )
@@ -414,40 +414,46 @@
                 let results = 0
                 servers.slice(1).map(server => this.compareAgainstReference(referenceServer, referenceSnapshots, server))
                     .map(async (promise) => {
-                        const { worstEntityId, worstTimeDiff, error, server } = await promise
+                        const { worstPointer, worstTimeDiff, worstSnapshotDiff, error, server } = await promise
                         const syncResult = this.state.syncCheck
                         const indexedServer = `${++results}/${servers.length - 1} - ${server}`
+                        const snapshotDiff = `${Math.sign(worstSnapshotDiff) < 0 ? Math.sign(worstSnapshotDiff) : "+"}${millisToHumanTime(Math.abs(worstSnapshotDiff))}`
                         if (error) {
                             syncResult.set(indexedServer, `An error happened: ${error}`)
-                        } else if (worstEntityId) {
-                            syncResult.set(indexedServer, `A difference of ${millisToHumanTime(worstTimeDiff)} was found. Check entity ${worstEntityId}`)
+                        } else if (worstPointer) {
+                            syncResult.set(indexedServer, `Snapshot diff: ${snapshotDiff}. A difference of ${millisToHumanTime(worstTimeDiff)} was found. Check pointer ${worstPointer}`)
                         } else {
-                            syncResult.set(indexedServer, 'No differences found')
+                            syncResult.set(indexedServer, `Snapshot diff: ${snapshotDiff}. No differences found`)
                         }
                         this.setState({ syncCheck: syncResult })
                     })
             }
 
             async compareAgainstReference(referenceServer, referenceSnapshots, server) {
-                let worstEntityId = undefined
+                let worstPointer = undefined
                 let worstTimeDiff = 0
                 let errorMessage = undefined
+                let worstSnapshotDiff = 0
 
                 try {
                     for (const entityType of ENTITY_TYPES) {
                         const [referenceSnapshotTime, referenceSnapshot] = referenceSnapshots.get(entityType)
                         const [serverSnapshotTime, serverSnapshot] = await this.fetchSnapshot(server, entityType)
-                        const { maxDiff, maxDiffEntity } = await this.diff(referenceServer, referenceSnapshotTime, referenceSnapshot, server, serverSnapshotTime, serverSnapshot)
+                        const snapshotTimeDiff = referenceSnapshotTime - serverSnapshotTime
+                        const { maxDiff, maxDiffPointer } = await this.diff(referenceServer, referenceSnapshotTime, referenceSnapshot, server, serverSnapshotTime, serverSnapshot)
+                        if (Math.abs(snapshotTimeDiff) > Math.abs(worstSnapshotDiff)) {
+                            worstSnapshotDiff = snapshotTimeDiff
+                        }
                         if (maxDiff > worstTimeDiff) {
                             worstTimeDiff = maxDiff
-                            worstEntityId = maxDiffEntity
+                            worstPointer = maxDiffPointer
                         }
                     }
                 } catch (error) {
                     errorMessage = `${error}`
                 }
 
-                return { worstEntityId, worstTimeDiff, server, error: errorMessage }
+                return { worstPointer, worstTimeDiff, worstSnapshotDiff, server, error: errorMessage }
             }
 
             /** Fetch the snapshot's content and timestamp */
@@ -462,7 +468,7 @@
                     throw new Error(`Failed to download snapshot. Status was: ${snapshotContentResponse.status}`)
                 }
                 const snapshotContent = await snapshotContentResponse.json()
-                return [lastIncludedDeploymentTimestamp, this.reverse(new Map(snapshotContent))]
+                return [lastIncludedDeploymentTimestamp, this.reverse(new Map(snapshotContent), server, type)]
             }
 
             /** Given a reference and compare snapshot, calculate the max differente */
@@ -485,7 +491,7 @@
                         if (compareEntity) {
                             conflictedEntitiesCompare.add(compareEntity)
                         }
-                        conflicts.push([referenceEntity, compareEntity])
+                        conflicts.push([pointer, referenceEntity, compareEntity])
                     }
                 }
 
@@ -497,10 +503,10 @@
                 const referenceEntityTimestamps = await this.checkEntityTimes(referenceServer, conflictedEntitiesReference)
                 const compareEntityTimestamps = await this.checkEntityTimes(compareServer, conflictedEntitiesCompare)
 
-                let maxDiffEntity = undefined
+                let maxDiffPointer = undefined
                 let maxDiff = 0
 
-                for (const [referenceEntity, compareEntity] of conflicts) {
+                for (const [pointer, referenceEntity, compareEntity] of conflicts) {
                     const { entityTimestamp: referenceEntityTimestamp, localTimestamp: referenceLocalTimestamp } = referenceEntityTimestamps.has(referenceEntity) ? referenceEntityTimestamps.get(referenceEntity) : ({ entityTimestamp: 0, localTimestamp: 0 })
                     const { entityTimestamp: compareEntityTimestamp, localTimestamp: compareLocalTimestamp } = compareEntityTimestamps.has(compareEntity) ? compareEntityTimestamps.get(compareEntity) : ({ entityTimestamp: 0, localTimestamp: 0 })
 
@@ -523,11 +529,11 @@
                     const diff = entityDiff + errorAge
                     if (diff > maxDiff) {
                         maxDiff = diff
-                        maxDiffEntity = compareEntity
+                        maxDiffPointer = pointer
                     }
                 }
 
-                return { maxDiffEntity, maxDiff }
+                return { maxDiffPointer, maxDiff }
             }
 
             /** Fetch all relevant timestamps for the given entities. We might need to make more than one request. */
@@ -562,12 +568,12 @@
             }
 
             // Takes a Map<EntityId, Pointer[]> and returns a Map<Pointer, EntityId>
-            reverse(snapshot) {
+            reverse(snapshot, server, type) {
                 const result = new Map()
                 for (const [ entityId, pointers ] of snapshot) {
                     for (const pointer of pointers) {
                         if (result.has(pointer)) {
-                            throw new Error(`Snapshot has pointer in more than one entity. First was '${result.get(pointer)}' and the second one is ${entityId}`)
+                            throw new Error(`Snapshot for type ${type} in server '${server}', has pointer in more than one entity. First was '${result.get(pointer)}' and the second one is ${entityId}`)
                         }
                         result.set(pointer, entityId)
                     }

--- a/index.html
+++ b/index.html
@@ -411,20 +411,21 @@
                 const referenceSnapshotsEntries = await Promise.all(ENTITY_TYPES.map((entityType) => this.fetchSnapshot(referenceServer, entityType).then(snapshot => [entityType, snapshot])))
                 const referenceSnapshots = new Map(referenceSnapshotsEntries)
 
-                const compares = await Promise.all(servers.slice(1).map(server => this.compareAgainstReference(referenceServer, referenceSnapshots, server)))
-
-                const syncResult = new Map()
-                for (const { worstEntityId, worstTimeDiff, error, server } of compares) {
-                    if (error) {
-                        syncResult.set(server, `An error happened: ${error}`)
-                    } else if (worstEntityId) {
-                        syncResult.set(server, `A difference of ${millisToHumanTime(worstTimeDiff)} was found. Check entity ${worstEntityId}`)
-                    } else {
-                        syncResult.set(server, 'No differences found')
-                    }
-                }
-
-                this.setState({ syncCheck: syncResult })
+                let results = 0
+                servers.slice(1).map(server => this.compareAgainstReference(referenceServer, referenceSnapshots, server))
+                    .map(async (promise) => {
+                        const { worstEntityId, worstTimeDiff, error, server } = await promise
+                        const syncResult = this.state.syncCheck
+                        const indexedServer = `${++results}/${servers.length - 1} - ${server}`
+                        if (error) {
+                            syncResult.set(indexedServer, `An error happened: ${error}`)
+                        } else if (worstEntityId) {
+                            syncResult.set(indexedServer, `A difference of ${millisToHumanTime(worstTimeDiff)} was found. Check entity ${worstEntityId}`)
+                        } else {
+                            syncResult.set(indexedServer, 'No differences found')
+                        }
+                        this.setState({ syncCheck: syncResult })
+                    })
             }
 
             async compareAgainstReference(referenceServer, referenceSnapshots, server) {

--- a/todo.txt
+++ b/todo.txt
@@ -1,5 +1,0 @@
-- Add a list at the bottom with all the commit hashes, their dates and how many servers are pointing to each one (and maybe a check to ensure all are in the same commit)
-- Add a check to ensure all the Current Times and all the Immutable Times are similar.
-- Identify somehow the nodes that are outside the DAO.
-
-- Add a timer telling when was the last refresh and how much left for the next one (and maybe a refresh now button).


### PR DESCRIPTION
We are making a few changes:
- We are splitting the mainnet servers into two: inside and outside the DAO
- https://peer-ap1.decentraland.org was inside the DAO, but not included on the monitor, so we added it
- We changed some of the fields that were being shown on the content server descriptions
- We added a sync monitor tool that compares content server snapshots