### PR TITLE
chore: remove realm-provider.decentraland.org

### DIFF
--- a/servers.js
+++ b/servers.js
@@ -7,7 +7,6 @@ const DAOMainnetServers = [
   "https://peer.melonwave.com",
   "https://peer.uadevops.com",
   "https://peer.dclnodes.io",
-  "https://realm-provider.decentraland.org/main",
   "https://realm-provider-ea.decentraland.org/main",
 ];
 


### PR DESCRIPTION
## Summary
- Remove `https://realm-provider.decentraland.org/main` from the DAO mainnet servers monitored list.

## Test plan
- [ ] Verify the monitor UI no longer queries `realm-provider.decentraland.org/main`.